### PR TITLE
Move MQTT settings to settings.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,16 @@ git submodule update --init --recursive
 
 2. Connect the esp32 dev-kit to your PC.  
 
-3. Go into the project folder, open terminal in the folder path and run the following command: 
+3. Go into the project folder, open terminal in the folder path and create `settings.h`
+by copying `settings-example.h`:
+
+```
+cp -i main/settings-example.h main/settings.h
+```
+
+Edit MQTT values in `settings.h`, if you want to use some other MQTT broker.
+
+Then run the following command:
 
 ```	
 make menuconfig

--- a/main/settings-example.h
+++ b/main/settings-example.h
@@ -1,0 +1,5 @@
+#define MQTT_TOPIC_PREFIX ""  // remember trailing slash if you use this e.g. "ruuvigw/"
+#define MQTT_SERVER "playground.ruuvi.com"
+#define MQTT_PORT 1883
+#define MQTT_USER NULL
+#define MQTT_PASSWORD NULL


### PR DESCRIPTION
With these changes MQTT server, username and password are out of VCS, in settings.h. There is also possibility to add a prefix for MQTT topic. This is very useful when your MQTT broker handles a lot of messages from different sources.

Disclaimer: I'm not a professional C/C++ programmer and there may be much better ways to solve this, which I don't know (yet).